### PR TITLE
Integrate OAuth into kotlin-reactive

### DIFF
--- a/kotlin-reactive/edge-service/pom.xml
+++ b/kotlin-reactive/edge-service/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.example</groupId>
@@ -14,17 +14,16 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.0.M5</version>
+		<version>2.0.1.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<kotlin.compiler.incremental>true</kotlin.compiler.incremental>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<kotlin.version>1.1.51</kotlin.version>
-		<spring-cloud.version>Finchley.BUILD-SNAPSHOT</spring-cloud.version>
+		<kotlin.version>1.2.20</kotlin.version>
+		<spring-cloud.version>Finchley.RC1</spring-cloud.version>
 	</properties>
 
 	<dependencies>
@@ -33,8 +32,12 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-kotlin</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -42,26 +45,23 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-netflix-hystrix</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-gateway-kotlin-extensions</artifactId>
-			<version>2.0.0.M3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webflux</artifactId>
+			<artifactId>spring-cloud-starter-oauth2</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
-			<artifactId>kotlin-stdlib-jre8</artifactId>
-			<version>${kotlin.version}</version>
+			<artifactId>kotlin-stdlib-jdk8</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-reflect</artifactId>
-			<version>${kotlin.version}</version>
 		</dependency>
 
 		<dependency>
@@ -99,29 +99,14 @@
 			<plugin>
 				<artifactId>kotlin-maven-plugin</artifactId>
 				<groupId>org.jetbrains.kotlin</groupId>
-				<version>${kotlin.version}</version>
 				<configuration>
+					<args>
+						<arg>-Xjsr305=strict</arg>
+					</args>
 					<compilerPlugins>
 						<plugin>spring</plugin>
 					</compilerPlugins>
-					<jvmTarget>1.8</jvmTarget>
 				</configuration>
-				<executions>
-					<execution>
-						<id>compile</id>
-						<phase>compile</phase>
-						<goals>
-							<goal>compile</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>test-compile</id>
-						<phase>test-compile</phase>
-						<goals>
-							<goal>test-compile</goal>
-						</goals>
-					</execution>
-				</executions>
 				<dependencies>
 					<dependency>
 						<groupId>org.jetbrains.kotlin</groupId>
@@ -135,14 +120,6 @@
 
 	<repositories>
 		<repository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
 			<url>https://repo.spring.io/milestone</url>
@@ -151,25 +128,4 @@
 			</snapshots>
 		</repository>
 	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>spring-snapshots</id>
-			<name>Spring Snapshots</name>
-			<url>https://repo.spring.io/snapshot</url>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
-		<pluginRepository>
-			<id>spring-milestones</id>
-			<name>Spring Milestones</name>
-			<url>https://repo.spring.io/milestone</url>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
-
-
 </project>

--- a/kotlin-reactive/edge-service/src/main/kotlin/com/example/edgeservice/EdgeServiceApplication.kt
+++ b/kotlin-reactive/edge-service/src/main/kotlin/com/example/edgeservice/EdgeServiceApplication.kt
@@ -1,6 +1,7 @@
 package com.example.edgeservice
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.cloud.client.discovery.DiscoveryClient
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient
@@ -22,6 +23,7 @@ import reactor.core.publisher.toMono
 
 @EnableDiscoveryClient
 @SpringBootApplication
+@EnableOAuth2Sso
 class EdgeServiceApplication
 
 fun main(args: Array<String>) {

--- a/kotlin-reactive/edge-service/src/main/resources/application.properties
+++ b/kotlin-reactive/edge-service/src/main/resources/application.properties
@@ -2,3 +2,13 @@ spring.application.name=edge-service
 server.port=8081
 
 endpoints.default.enabled=true
+
+security.oauth2.client.client-id=0oadx7zrsjjgIMgQZ0h7
+security.oauth2.client.client-secret=vcBjfdFw9rDUsWGasf0ramwfSu_xHfENWWEinq-y
+security.oauth2.client.access-token-uri=https://dev-158606.oktapreview.com/oauth2/default/v1/token
+security.oauth2.client.user-authorization-uri=https://dev-158606.oktapreview.com/oauth2/default/v1/authorize
+security.oauth2.client.scope=openid profile email
+security.oauth2.resource.filter-order=3
+security.oauth2.resource.user-info-uri=https://dev-158606.oktapreview.com/oauth2/default/v1/userinfo
+security.oauth2.resource.token-info-uri=https://dev-158606.oktapreview.com/oauth2/default/v1/introspect
+security.oauth2.resource.prefer-token-info=false


### PR DESCRIPTION
@joshlong I tried upgrading all the dependencies to their latest releases, and integrating Spring Security OAuth into the edge-service project.

Unfortunately, the `edge-service` fails to compile after these changes. Any ideas?

```
[INFO] --- kotlin-maven-plugin:1.2.20:compile (compile) @ edge-service ---
[INFO] Applied plugin: 'spring'
[ERROR]  .../edge-service/.../EdgeServiceApplication.kt: (10, 60) Unresolved reference: RoutePredicates
[ERROR]  .../edge-service/.../EdgeServiceApplication.kt: (11, 48) Unresolved reference: gateway
[ERROR]  .../edge-service/.../EdgeServiceApplication.kt: (48, 81) No value passed for parameter 'p1'
[ERROR]  .../edge-service/.../EdgeServiceApplication.kt: (51, 21) Unresolved reference: gateway
[ERROR]  .../edge-service/.../EdgeServiceApplication.kt: (52, 25) Unresolved reference: route
[ERROR]  .../edge-service/.../EdgeServiceApplication.kt: (53, 29) Unresolved reference: id
[ERROR]  .../edge-service/.../EdgeServiceApplication.kt: (54, 29) Unresolved reference: predicate
[ERROR]  .../edge-service/.../EdgeServiceApplication.kt: (54, 39) Unresolved reference: path
[ERROR]  .../edge-service/.../EdgeServiceApplication.kt: (55, 29) Unresolved reference: uri
```

Steps to reproduce:

```
git clone git@github.com:mraible/cloud-native-pwas.git
cd cloud-native-pwas/kotlin-reactive
git checkout reactive-oauth
cd edge-service
./mvnw spring-boot:run
```